### PR TITLE
linenoiseHistoryFree fix: history_len must be set to 0

### DIFF
--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -1163,12 +1163,14 @@ void linenoiseFree(void *ptr) {
 
 void linenoiseHistoryFree(void) {
     if (history) {
-        for (int j = 0; j < history_len; j++) {
+        int j;
+
+        for (j = 0; j < history_len; j++)
             free(history[j]);
-        }
         free(history);
+        history = NULL;
+        history_len = 0;
     }
-    history = NULL;
 }
 
 /* This is the API call to add a new entry in the linenoise history.


### PR DESCRIPTION
**linenoiseHistoryFree()** fix: *history_len* must be set to 0, otherwise you can have guru meditation errors using it.

```
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x400d9f03  PS      : 0x00060e30  A0      : 0x800d7299  A1      : 0x3ffbb2b0  
A2      : 0x00000000  A3      : 0x3ffaf0fc  A4      : 0x3f409324  A5      : 0x3ffb3b78
A6      : 0x3ffb3b7c  A7      : 0x40404040  A8      : 0x00000000  A9      : 0x00000000  
A10     : 0x3ffaf0fc  A11     : 0x3f4064c4  A12     : 0x00000001  A13     : 0x3ffbb180
A14     : 0x0000001f  A15     : 0x3ffbb180  SAR     : 0x00000018  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000000  LBEG    : 0x400f538c  LEND    : 0x400f53c2  LCOUNT  : 0x0000003c
```

